### PR TITLE
Gateway federation review changes

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Environment.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Environment.java
@@ -59,6 +59,28 @@ public class Environment implements Serializable {
     private String[] visibilityRoles;
     private String visibility;
 
+    public Environment(Environment environment) {
+        this.type = environment.type;
+        this.serverURL = environment.serverURL;
+        this.userName = environment.userName;
+        this.password = environment.password;
+        this.apiGatewayEndpoint = environment.apiGatewayEndpoint;
+        this.websocketGatewayEndpoint = environment.websocketGatewayEndpoint;
+        this.webSubGatewayEndpoint = environment.webSubGatewayEndpoint;
+        this.isDefault = environment.isDefault;
+        this.id = environment.id;
+        this.uuid = environment.uuid;
+        this.name = environment.name;
+        this.displayName = environment.displayName;
+        this.description = environment.description;
+        this.isReadOnly = environment.isReadOnly;
+        this.vhosts = new ArrayList<>(environment.vhosts);
+        this.provider = environment.provider;
+        this.gatewayType = environment.gatewayType;
+        this.additionalProperties = new HashMap<>(environment.additionalProperties);
+        this.visibilityRoles = environment.visibilityRoles;
+        this.visibility = environment.visibility;
+    }
     private GatewayVisibilityPermissionConfigurationDTO permissions = new GatewayVisibilityPermissionConfigurationDTO();
 
     public boolean isDefault() {

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Environment.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Environment.java
@@ -59,6 +59,9 @@ public class Environment implements Serializable {
     private String[] visibilityRoles;
     private String visibility;
 
+    public Environment() {
+    }
+
     public Environment(Environment environment) {
         this.type = environment.type;
         this.serverURL = environment.serverURL;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -69,6 +69,7 @@ import org.wso2.carbon.apimgt.impl.alertmgt.AlertMgtConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dao.LabelsDAO;
 import org.wso2.carbon.apimgt.impl.dao.constants.SQLConstants;
+import org.wso2.carbon.apimgt.impl.deployer.ExternalGatewayDeployer;
 import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowProperties;
 import org.wso2.carbon.apimgt.impl.factory.PersistenceFactory;
@@ -157,6 +158,10 @@ public class APIAdminImpl implements APIAdmin {
         // add read only environments first and dynamic environments later
         APIUtil.getReadOnlyEnvironments().values().stream().filter(env -> !dynamicEnvNames.contains(env.getName())).forEach(allEnvs::add);
         allEnvs.addAll(dynamicEnvs);
+
+        for (Environment env : allEnvs) {
+            decryptGatewayConfigurationValues(env);
+        }
         return allEnvs;
     }
 
@@ -175,6 +180,7 @@ public class APIAdminImpl implements APIAdmin {
                 );
             }
         }
+        maskValues(env);
         return env;
     }
 
@@ -189,6 +195,8 @@ public class APIAdminImpl implements APIAdmin {
                             String.format("name '%s'", environment.getName())));
         }
         validateForUniqueVhostNames(environment);
+        Environment environmentToStore =  new Environment(environment);
+        encryptGatewayConfigurationValues(null, environmentToStore);
         return apiMgtDAO.addEnvironment(tenantDomain, environment);
     }
 
@@ -792,6 +800,31 @@ public class APIAdminImpl implements APIAdmin {
         }
     }
 
+    private void encryptGatewayConfigurationValues(Environment retrievedGatewayConfigurationDTO,
+                                                   Environment updatedGatewayConfigurationDto)
+            throws APIManagementException {
+
+        ExternalGatewayDeployer gatewayDeployer = ServiceReferenceHolder.getInstance()
+                .getExternalGatewayDeployer(updatedGatewayConfigurationDto.getGatewayType());
+        if (gatewayDeployer != null) {
+            Map<String, String> additionalProperties = updatedGatewayConfigurationDto.getAdditionalProperties();
+            for (ConfigurationDto configurationDto : gatewayDeployer.getConnectionConfigurations()) {
+                if (configurationDto.isMask()) {
+                    String value = additionalProperties.get(configurationDto.getName());
+                    if (APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD.equals(value)) {
+                        if (retrievedGatewayConfigurationDTO != null) {
+                            String unModifiedValue = retrievedGatewayConfigurationDTO.getAdditionalProperties()
+                                    .get(configurationDto.getName());
+                            additionalProperties.replace(configurationDto.getName(), unModifiedValue);
+                        }
+                    } else if (StringUtils.isNotEmpty(value)) {
+                        additionalProperties.replace(configurationDto.getName(), String.valueOf(encryptValues(value)));
+                    }
+                }
+            }
+        }
+    }
+
     private KeyManagerConfigurationDTO decryptKeyManagerConfigurationValues(
             KeyManagerConfigurationDTO keyManagerConfigurationDTO)
             throws APIManagementException {
@@ -805,6 +838,20 @@ public class APIAdminImpl implements APIAdmin {
             }
         }
         return keyManagerConfigurationDTO;
+    }
+
+    private Environment decryptGatewayConfigurationValues(Environment environment)
+            throws APIManagementException {
+
+        Map<String, String> additionalProperties = environment.getAdditionalProperties();
+        for (Map.Entry<String, String> entry : additionalProperties.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value != null) {
+                additionalProperties.replace(key, String.valueOf(decryptValue(value)));
+            }
+        }
+        return environment;
     }
 
     private Object decryptValue(Object value) throws APIManagementException {
@@ -1456,6 +1503,20 @@ public class APIAdminImpl implements APIAdmin {
         Map<String, Object> additionalProperties = keyManagerConfigurationDTO.getAdditionalProperties();
         List<ConfigurationDto> connectionConfigurations =
                 keyManagerConnectorConfiguration.getConnectionConfigurations();
+        for (ConfigurationDto connectionConfiguration : connectionConfigurations) {
+            if (connectionConfiguration.isMask()) {
+                additionalProperties.replace(connectionConfiguration.getName(),
+                        APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD);
+            }
+        }
+    }
+
+    private void maskValues(Environment environment) {
+        ExternalGatewayDeployer gatewayDeployer = ServiceReferenceHolder.getInstance()
+                .getExternalGatewayDeployer(environment.getGatewayType());
+
+        Map<String, String> additionalProperties = environment.getAdditionalProperties();
+        List<ConfigurationDto> connectionConfigurations = gatewayDeployer.getConnectionConfigurations();
         for (ConfigurationDto connectionConfiguration : connectionConfigurations) {
             if (connectionConfiguration.isMask()) {
                 additionalProperties.replace(connectionConfiguration.getName(),

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -15340,6 +15340,7 @@ public class ApiMgtDAO {
                     String displayName = rs.getString("DISPLAY_NAME");
                     String description = rs.getString("DESCRIPTION");
                     String provider = rs.getString("PROVIDER");
+                    String gatewayType = rs.getString("GATEWAY_TYPE");
                     Map<String, String> additionalProperties = new HashMap();
                     try (InputStream configuration = rs.getBinaryStream("CONFIGURATION")) {
                         if (configuration != null) {
@@ -15357,6 +15358,7 @@ public class ApiMgtDAO {
                     env.setDisplayName(displayName);
                     env.setDescription(description);
                     env.setProvider(provider);
+                    env.setGatewayType(gatewayType);
                     env.setVhosts(getVhostGatewayEnvironments(connection, id));
                     env.setPermissions(getGatewayVisibilityPermissions(uuid));
                     env.setAdditionalProperties(additionalProperties);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/EnvironmentsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/EnvironmentsApi.java
@@ -54,6 +54,24 @@ EnvironmentsApiService delegate = new EnvironmentsApiServiceImpl();
         return delegate.environmentsEnvironmentIdDelete(environmentId, securityContext);
     }
 
+    @GET
+    @Path("/{environmentId}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get a Gateway Environment Configuration", notes = "Retrieve a single Gateway Environment Configuration. We should provide the Id of the Environment as a path parameter. ", response = EnvironmentDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:environment_manage", description = "Manage gateway environments")
+        })
+    }, tags={ "Environments",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Gateway Environment Configuration returned ", response = EnvironmentDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
+    public Response environmentsEnvironmentIdGet(@ApiParam(value = "Environment UUID (or Environment name defined in config) ",required=true) @PathParam("environmentId") String environmentId) throws APIManagementException{
+        return delegate.environmentsEnvironmentIdGet(environmentId, securityContext);
+    }
+
     @PUT
     @Path("/{environmentId}")
     @Consumes({ "application/json" })

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/EnvironmentsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/EnvironmentsApiService.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.SecurityContext;
 
 public interface EnvironmentsApiService {
       public Response environmentsEnvironmentIdDelete(String environmentId, MessageContext messageContext) throws APIManagementException;
+      public Response environmentsEnvironmentIdGet(String environmentId, MessageContext messageContext) throws APIManagementException;
       public Response environmentsEnvironmentIdPut(String environmentId, EnvironmentDTO environmentDTO, MessageContext messageContext) throws APIManagementException;
       public Response environmentsGet(MessageContext messageContext) throws APIManagementException;
       public Response environmentsPost(EnvironmentDTO environmentDTO, MessageContext messageContext) throws APIManagementException;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/GatewayConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/GatewayConfigurationDTO.java
@@ -1,0 +1,244 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class GatewayConfigurationDTO   {
+  
+    private String name = null;
+    private String label = null;
+    private String type = null;
+    private Boolean required = null;
+    private Boolean mask = null;
+    private Boolean multiple = null;
+    private String tooltip = null;
+    private Object _default = null;
+    private List<Object> values = new ArrayList<Object>();
+
+  /**
+   **/
+  public GatewayConfigurationDTO name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "consumer_key", value = "")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   **/
+  public GatewayConfigurationDTO label(String label) {
+    this.label = label;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Consumer Key", value = "")
+  @JsonProperty("label")
+  public String getLabel() {
+    return label;
+  }
+  public void setLabel(String label) {
+    this.label = label;
+  }
+
+  /**
+   **/
+  public GatewayConfigurationDTO type(String type) {
+    this.type = type;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "select", value = "")
+  @JsonProperty("type")
+  public String getType() {
+    return type;
+  }
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  /**
+   **/
+  public GatewayConfigurationDTO required(Boolean required) {
+    this.required = required;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("required")
+  public Boolean isRequired() {
+    return required;
+  }
+  public void setRequired(Boolean required) {
+    this.required = required;
+  }
+
+  /**
+   **/
+  public GatewayConfigurationDTO mask(Boolean mask) {
+    this.mask = mask;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("mask")
+  public Boolean isMask() {
+    return mask;
+  }
+  public void setMask(Boolean mask) {
+    this.mask = mask;
+  }
+
+  /**
+   **/
+  public GatewayConfigurationDTO multiple(Boolean multiple) {
+    this.multiple = multiple;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("multiple")
+  public Boolean isMultiple() {
+    return multiple;
+  }
+  public void setMultiple(Boolean multiple) {
+    this.multiple = multiple;
+  }
+
+  /**
+   **/
+  public GatewayConfigurationDTO tooltip(String tooltip) {
+    this.tooltip = tooltip;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Enter username", value = "")
+  @JsonProperty("tooltip")
+  public String getTooltip() {
+    return tooltip;
+  }
+  public void setTooltip(String tooltip) {
+    this.tooltip = tooltip;
+  }
+
+  /**
+   **/
+  public GatewayConfigurationDTO _default(Object _default) {
+    this._default = _default;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "admin", value = "")
+      @Valid
+  @JsonProperty("default")
+  public Object getDefault() {
+    return _default;
+  }
+  public void setDefault(Object _default) {
+    this._default = _default;
+  }
+
+  /**
+   **/
+  public GatewayConfigurationDTO values(List<Object> values) {
+    this.values = values;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("values")
+  public List<Object> getValues() {
+    return values;
+  }
+  public void setValues(List<Object> values) {
+    this.values = values;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    GatewayConfigurationDTO gatewayConfiguration = (GatewayConfigurationDTO) o;
+    return Objects.equals(name, gatewayConfiguration.name) &&
+        Objects.equals(label, gatewayConfiguration.label) &&
+        Objects.equals(type, gatewayConfiguration.type) &&
+        Objects.equals(required, gatewayConfiguration.required) &&
+        Objects.equals(mask, gatewayConfiguration.mask) &&
+        Objects.equals(multiple, gatewayConfiguration.multiple) &&
+        Objects.equals(tooltip, gatewayConfiguration.tooltip) &&
+        Objects.equals(_default, gatewayConfiguration._default) &&
+        Objects.equals(values, gatewayConfiguration.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, label, type, required, mask, multiple, tooltip, _default, values);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class GatewayConfigurationDTO {\n");
+    
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    label: ").append(toIndentedString(label)).append("\n");
+    sb.append("    type: ").append(toIndentedString(type)).append("\n");
+    sb.append("    required: ").append(toIndentedString(required)).append("\n");
+    sb.append("    mask: ").append(toIndentedString(mask)).append("\n");
+    sb.append("    multiple: ").append(toIndentedString(multiple)).append("\n");
+    sb.append("    tooltip: ").append(toIndentedString(tooltip)).append("\n");
+    sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
+    sb.append("    values: ").append(toIndentedString(values)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerConfigurationDTO.java
@@ -20,7 +20,7 @@ import javax.validation.Valid;
 
 
 
-public class ConfigurationDTO   {
+public class KeyManagerConfigurationDTO   {
   
     private String name = null;
     private String label = null;
@@ -34,7 +34,7 @@ public class ConfigurationDTO   {
 
   /**
    **/
-  public ConfigurationDTO name(String name) {
+  public KeyManagerConfigurationDTO name(String name) {
     this.name = name;
     return this;
   }
@@ -51,7 +51,7 @@ public class ConfigurationDTO   {
 
   /**
    **/
-  public ConfigurationDTO label(String label) {
+  public KeyManagerConfigurationDTO label(String label) {
     this.label = label;
     return this;
   }
@@ -68,7 +68,7 @@ public class ConfigurationDTO   {
 
   /**
    **/
-  public ConfigurationDTO type(String type) {
+  public KeyManagerConfigurationDTO type(String type) {
     this.type = type;
     return this;
   }
@@ -85,7 +85,7 @@ public class ConfigurationDTO   {
 
   /**
    **/
-  public ConfigurationDTO required(Boolean required) {
+  public KeyManagerConfigurationDTO required(Boolean required) {
     this.required = required;
     return this;
   }
@@ -102,7 +102,7 @@ public class ConfigurationDTO   {
 
   /**
    **/
-  public ConfigurationDTO mask(Boolean mask) {
+  public KeyManagerConfigurationDTO mask(Boolean mask) {
     this.mask = mask;
     return this;
   }
@@ -119,7 +119,7 @@ public class ConfigurationDTO   {
 
   /**
    **/
-  public ConfigurationDTO multiple(Boolean multiple) {
+  public KeyManagerConfigurationDTO multiple(Boolean multiple) {
     this.multiple = multiple;
     return this;
   }
@@ -136,13 +136,13 @@ public class ConfigurationDTO   {
 
   /**
    **/
-  public ConfigurationDTO tooltip(String tooltip) {
+  public KeyManagerConfigurationDTO tooltip(String tooltip) {
     this.tooltip = tooltip;
     return this;
   }
 
   
-  @ApiModelProperty(example = "Enter username", value = "")
+  @ApiModelProperty(example = "Enter username to connect to key manager", value = "")
   @JsonProperty("tooltip")
   public String getTooltip() {
     return tooltip;
@@ -153,7 +153,7 @@ public class ConfigurationDTO   {
 
   /**
    **/
-  public ConfigurationDTO _default(Object _default) {
+  public KeyManagerConfigurationDTO _default(Object _default) {
     this._default = _default;
     return this;
   }
@@ -171,7 +171,7 @@ public class ConfigurationDTO   {
 
   /**
    **/
-  public ConfigurationDTO values(List<Object> values) {
+  public KeyManagerConfigurationDTO values(List<Object> values) {
     this.values = values;
     return this;
   }
@@ -195,16 +195,16 @@ public class ConfigurationDTO   {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    ConfigurationDTO _configuration = (ConfigurationDTO) o;
-    return Objects.equals(name, _configuration.name) &&
-        Objects.equals(label, _configuration.label) &&
-        Objects.equals(type, _configuration.type) &&
-        Objects.equals(required, _configuration.required) &&
-        Objects.equals(mask, _configuration.mask) &&
-        Objects.equals(multiple, _configuration.multiple) &&
-        Objects.equals(tooltip, _configuration.tooltip) &&
-        Objects.equals(_default, _configuration._default) &&
-        Objects.equals(values, _configuration.values);
+    KeyManagerConfigurationDTO keyManagerConfiguration = (KeyManagerConfigurationDTO) o;
+    return Objects.equals(name, keyManagerConfiguration.name) &&
+        Objects.equals(label, keyManagerConfiguration.label) &&
+        Objects.equals(type, keyManagerConfiguration.type) &&
+        Objects.equals(required, keyManagerConfiguration.required) &&
+        Objects.equals(mask, keyManagerConfiguration.mask) &&
+        Objects.equals(multiple, keyManagerConfiguration.multiple) &&
+        Objects.equals(tooltip, keyManagerConfiguration.tooltip) &&
+        Objects.equals(_default, keyManagerConfiguration._default) &&
+        Objects.equals(values, keyManagerConfiguration.values);
   }
 
   @Override
@@ -215,7 +215,7 @@ public class ConfigurationDTO   {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class ConfigurationDTO {\n");
+    sb.append("class KeyManagerConfigurationDTO {\n");
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    label: ").append(toIndentedString(label)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
@@ -6,7 +6,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsFederatedGatewayConfigurationDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsGatewayConfigurationDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsKeyManagerConfigurationDTO;
 import javax.validation.constraints.*;
 
@@ -29,7 +29,7 @@ public class SettingsDTO   {
     private Boolean isJWTEnabledForLoginTokens = false;
     private Boolean orgAccessControlEnabled = null;
     private List<SettingsKeyManagerConfigurationDTO> keyManagerConfiguration = new ArrayList<SettingsKeyManagerConfigurationDTO>();
-    private List<SettingsFederatedGatewayConfigurationDTO> federatedGatewayConfiguration = new ArrayList<SettingsFederatedGatewayConfigurationDTO>();
+    private List<SettingsGatewayConfigurationDTO> gatewayConfiguration = new ArrayList<SettingsGatewayConfigurationDTO>();
     private Boolean analyticsEnabled = null;
     private Boolean transactionCounterEnable = null;
 
@@ -122,20 +122,20 @@ public class SettingsDTO   {
 
   /**
    **/
-  public SettingsDTO federatedGatewayConfiguration(List<SettingsFederatedGatewayConfigurationDTO> federatedGatewayConfiguration) {
-    this.federatedGatewayConfiguration = federatedGatewayConfiguration;
+  public SettingsDTO gatewayConfiguration(List<SettingsGatewayConfigurationDTO> gatewayConfiguration) {
+    this.gatewayConfiguration = gatewayConfiguration;
     return this;
   }
 
   
   @ApiModelProperty(value = "")
       @Valid
-  @JsonProperty("federatedGatewayConfiguration")
-  public List<SettingsFederatedGatewayConfigurationDTO> getFederatedGatewayConfiguration() {
-    return federatedGatewayConfiguration;
+  @JsonProperty("gatewayConfiguration")
+  public List<SettingsGatewayConfigurationDTO> getGatewayConfiguration() {
+    return gatewayConfiguration;
   }
-  public void setFederatedGatewayConfiguration(List<SettingsFederatedGatewayConfigurationDTO> federatedGatewayConfiguration) {
-    this.federatedGatewayConfiguration = federatedGatewayConfiguration;
+  public void setGatewayConfiguration(List<SettingsGatewayConfigurationDTO> gatewayConfiguration) {
+    this.gatewayConfiguration = gatewayConfiguration;
   }
 
   /**
@@ -189,14 +189,14 @@ public class SettingsDTO   {
         Objects.equals(isJWTEnabledForLoginTokens, settings.isJWTEnabledForLoginTokens) &&
         Objects.equals(orgAccessControlEnabled, settings.orgAccessControlEnabled) &&
         Objects.equals(keyManagerConfiguration, settings.keyManagerConfiguration) &&
-        Objects.equals(federatedGatewayConfiguration, settings.federatedGatewayConfiguration) &&
+        Objects.equals(gatewayConfiguration, settings.gatewayConfiguration) &&
         Objects.equals(analyticsEnabled, settings.analyticsEnabled) &&
         Objects.equals(transactionCounterEnable, settings.transactionCounterEnable);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(scopes, gatewayTypes, isJWTEnabledForLoginTokens, orgAccessControlEnabled, keyManagerConfiguration, federatedGatewayConfiguration, analyticsEnabled, transactionCounterEnable);
+    return Objects.hash(scopes, gatewayTypes, isJWTEnabledForLoginTokens, orgAccessControlEnabled, keyManagerConfiguration, gatewayConfiguration, analyticsEnabled, transactionCounterEnable);
   }
 
   @Override
@@ -209,7 +209,7 @@ public class SettingsDTO   {
     sb.append("    isJWTEnabledForLoginTokens: ").append(toIndentedString(isJWTEnabledForLoginTokens)).append("\n");
     sb.append("    orgAccessControlEnabled: ").append(toIndentedString(orgAccessControlEnabled)).append("\n");
     sb.append("    keyManagerConfiguration: ").append(toIndentedString(keyManagerConfiguration)).append("\n");
-    sb.append("    federatedGatewayConfiguration: ").append(toIndentedString(federatedGatewayConfiguration)).append("\n");
+    sb.append("    gatewayConfiguration: ").append(toIndentedString(gatewayConfiguration)).append("\n");
     sb.append("    analyticsEnabled: ").append(toIndentedString(analyticsEnabled)).append("\n");
     sb.append("    transactionCounterEnable: ").append(toIndentedString(transactionCounterEnable)).append("\n");
     sb.append("}");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsGatewayConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsGatewayConfigurationDTO.java
@@ -6,7 +6,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ConfigurationDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.GatewayConfigurationDTO;
 import javax.validation.constraints.*;
 
 
@@ -21,15 +21,15 @@ import javax.validation.Valid;
 
 
 
-public class SettingsFederatedGatewayConfigurationDTO   {
+public class SettingsGatewayConfigurationDTO   {
   
     private String type = null;
     private String displayName = null;
-    private List<ConfigurationDTO> configurations = new ArrayList<ConfigurationDTO>();
+    private List<GatewayConfigurationDTO> configurations = new ArrayList<GatewayConfigurationDTO>();
 
   /**
    **/
-  public SettingsFederatedGatewayConfigurationDTO type(String type) {
+  public SettingsGatewayConfigurationDTO type(String type) {
     this.type = type;
     return this;
   }
@@ -46,7 +46,7 @@ public class SettingsFederatedGatewayConfigurationDTO   {
 
   /**
    **/
-  public SettingsFederatedGatewayConfigurationDTO displayName(String displayName) {
+  public SettingsGatewayConfigurationDTO displayName(String displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -63,7 +63,7 @@ public class SettingsFederatedGatewayConfigurationDTO   {
 
   /**
    **/
-  public SettingsFederatedGatewayConfigurationDTO configurations(List<ConfigurationDTO> configurations) {
+  public SettingsGatewayConfigurationDTO configurations(List<GatewayConfigurationDTO> configurations) {
     this.configurations = configurations;
     return this;
   }
@@ -72,10 +72,10 @@ public class SettingsFederatedGatewayConfigurationDTO   {
   @ApiModelProperty(value = "")
       @Valid
   @JsonProperty("configurations")
-  public List<ConfigurationDTO> getConfigurations() {
+  public List<GatewayConfigurationDTO> getConfigurations() {
     return configurations;
   }
-  public void setConfigurations(List<ConfigurationDTO> configurations) {
+  public void setConfigurations(List<GatewayConfigurationDTO> configurations) {
     this.configurations = configurations;
   }
 
@@ -88,10 +88,10 @@ public class SettingsFederatedGatewayConfigurationDTO   {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SettingsFederatedGatewayConfigurationDTO settingsFederatedGatewayConfiguration = (SettingsFederatedGatewayConfigurationDTO) o;
-    return Objects.equals(type, settingsFederatedGatewayConfiguration.type) &&
-        Objects.equals(displayName, settingsFederatedGatewayConfiguration.displayName) &&
-        Objects.equals(configurations, settingsFederatedGatewayConfiguration.configurations);
+    SettingsGatewayConfigurationDTO settingsGatewayConfiguration = (SettingsGatewayConfigurationDTO) o;
+    return Objects.equals(type, settingsGatewayConfiguration.type) &&
+        Objects.equals(displayName, settingsGatewayConfiguration.displayName) &&
+        Objects.equals(configurations, settingsGatewayConfiguration.configurations);
   }
 
   @Override
@@ -102,7 +102,7 @@ public class SettingsFederatedGatewayConfigurationDTO   {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class SettingsFederatedGatewayConfigurationDTO {\n");
+    sb.append("class SettingsGatewayConfigurationDTO {\n");
     
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsKeyManagerConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsKeyManagerConfigurationDTO.java
@@ -6,7 +6,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ConfigurationDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.KeyManagerConfigurationDTO;
 import javax.validation.constraints.*;
 
 
@@ -27,8 +27,8 @@ public class SettingsKeyManagerConfigurationDTO   {
     private String displayName = null;
     private String defaultConsumerKeyClaim = null;
     private String defaultScopesClaim = null;
-    private List<ConfigurationDTO> configurations = new ArrayList<ConfigurationDTO>();
-    private List<ConfigurationDTO> endpointConfigurations = new ArrayList<ConfigurationDTO>();
+    private List<KeyManagerConfigurationDTO> configurations = new ArrayList<KeyManagerConfigurationDTO>();
+    private List<KeyManagerConfigurationDTO> endpointConfigurations = new ArrayList<KeyManagerConfigurationDTO>();
 
   /**
    **/
@@ -100,7 +100,7 @@ public class SettingsKeyManagerConfigurationDTO   {
 
   /**
    **/
-  public SettingsKeyManagerConfigurationDTO configurations(List<ConfigurationDTO> configurations) {
+  public SettingsKeyManagerConfigurationDTO configurations(List<KeyManagerConfigurationDTO> configurations) {
     this.configurations = configurations;
     return this;
   }
@@ -109,16 +109,16 @@ public class SettingsKeyManagerConfigurationDTO   {
   @ApiModelProperty(value = "")
       @Valid
   @JsonProperty("configurations")
-  public List<ConfigurationDTO> getConfigurations() {
+  public List<KeyManagerConfigurationDTO> getConfigurations() {
     return configurations;
   }
-  public void setConfigurations(List<ConfigurationDTO> configurations) {
+  public void setConfigurations(List<KeyManagerConfigurationDTO> configurations) {
     this.configurations = configurations;
   }
 
   /**
    **/
-  public SettingsKeyManagerConfigurationDTO endpointConfigurations(List<ConfigurationDTO> endpointConfigurations) {
+  public SettingsKeyManagerConfigurationDTO endpointConfigurations(List<KeyManagerConfigurationDTO> endpointConfigurations) {
     this.endpointConfigurations = endpointConfigurations;
     return this;
   }
@@ -127,10 +127,10 @@ public class SettingsKeyManagerConfigurationDTO   {
   @ApiModelProperty(value = "")
       @Valid
   @JsonProperty("endpointConfigurations")
-  public List<ConfigurationDTO> getEndpointConfigurations() {
+  public List<KeyManagerConfigurationDTO> getEndpointConfigurations() {
     return endpointConfigurations;
   }
-  public void setEndpointConfigurations(List<ConfigurationDTO> endpointConfigurations) {
+  public void setEndpointConfigurations(List<KeyManagerConfigurationDTO> endpointConfigurations) {
     this.endpointConfigurations = endpointConfigurations;
   }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/VHostDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/VHostDTO.java
@@ -40,7 +40,7 @@ public class VHostDTO   {
   @ApiModelProperty(example = "mg.wso2.com", required = true, value = "")
   @JsonProperty("host")
   @NotNull
- @Pattern(regexp="^(([a-zA-Z0-9\\{\\}]|[a-zA-Z0-9\\{\\}][a-zA-Z0-9\\-\\{\\}]*[a-zA-Z0-9\\{\\}])\\.)*([A-Za-z0-9\\{\\}]|[A-Za-z0-9\\{\\}][A-Za-z0-9\\-\\{\\}]*[A-Za-z0-9\\{\\}])$") @Size(min=1,max=255)  public String getHost() {
+ @Size(min=1,max=255)  public String getHost() {
     return host;
   }
   public void setHost(String host) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/EnvironmentsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/EnvironmentsApiServiceImpl.java
@@ -59,6 +59,19 @@ public class EnvironmentsApiServiceImpl implements EnvironmentsApiService {
         return Response.ok().build();
     }
 
+    @Override
+    public Response environmentsEnvironmentIdGet(String environmentId, MessageContext messageContext) throws APIManagementException {
+        APIAdmin apiAdmin = new APIAdminImpl();
+        String organization = RestApiUtil.getValidatedOrganization(messageContext);
+        Environment environment = apiAdmin.getEnvironment(organization, environmentId);
+        if (environment != null) {
+            EnvironmentDTO environmentDTO = EnvironmentMappingUtil.fromEnvToEnvDTO(environment);
+            return Response.ok().entity(environmentDTO).build();
+        }
+        throw new APIManagementException("Requested Gateway Environment not found",
+                ExceptionCodes.GATEWAY_ENVIRONMENT_NOT_FOUND);
+    }
+
     /**
      * Update gateway environment
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
@@ -30,10 +30,7 @@ import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.deployer.ExternalGatewayDeployer;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ConfigurationDTO;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsDTO;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsFederatedGatewayConfigurationDTO;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsKeyManagerConfigurationDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.*;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
 import java.io.IOException;
@@ -61,7 +58,7 @@ public class SettingsMappingUtil {
         if (isUserAvailable) {
             settingsDTO.setAnalyticsEnabled(APIUtil.isAnalyticsEnabled());
             settingsDTO.setKeyManagerConfiguration(getSettingsKeyManagerConfigurationDTOList());
-            settingsDTO.setFederatedGatewayConfiguration(getSettingsFederatedGatewayConfigurationDTOList());
+            settingsDTO.setGatewayConfiguration(getSettingsGatewayConfigurationDTOList());
         }
         settingsDTO.setScopes(getScopeList());
         settingsDTO.setGatewayTypes(APIUtil.getGatewayTypes());
@@ -115,26 +112,44 @@ public class SettingsMappingUtil {
         settingsKeyManagerConfigurationDTO.setDefaultConsumerKeyClaim(consumerKeyClaim);
         if (connectionConfigurationDtoList != null) {
             for (ConfigurationDto configurationDto : connectionConfigurationDtoList) {
-                ConfigurationDTO keyManagerConfigurationDTO = fromConfigurationToConfigurationDTO(configurationDto);
+                KeyManagerConfigurationDTO keyManagerConfigurationDTO = new KeyManagerConfigurationDTO();
+                keyManagerConfigurationDTO.setName(configurationDto.getName());
+                keyManagerConfigurationDTO.setLabel(configurationDto.getLabel());
+                keyManagerConfigurationDTO.setType(configurationDto.getType());
+                keyManagerConfigurationDTO.setRequired(configurationDto.isRequired());
+                keyManagerConfigurationDTO.setMask(configurationDto.isMask());
+                keyManagerConfigurationDTO.setMultiple(configurationDto.isMultiple());
+                keyManagerConfigurationDTO.setTooltip(configurationDto.getTooltip());
+                keyManagerConfigurationDTO.setDefault(configurationDto.getDefaultValue());
+                keyManagerConfigurationDTO.setValues(configurationDto.getValues());
                 settingsKeyManagerConfigurationDTO.getConfigurations().add(keyManagerConfigurationDTO);
             }
         }
         if (endpointConfigurations != null) {
             for (ConfigurationDto configurationDto : endpointConfigurations) {
-                ConfigurationDTO keyManagerConfigurationDTO = fromConfigurationToConfigurationDTO(configurationDto);
+                KeyManagerConfigurationDTO keyManagerConfigurationDTO = new KeyManagerConfigurationDTO();
+                keyManagerConfigurationDTO.setName(configurationDto.getName());
+                keyManagerConfigurationDTO.setLabel(configurationDto.getLabel());
+                keyManagerConfigurationDTO.setType(configurationDto.getType());
+                keyManagerConfigurationDTO.setRequired(configurationDto.isRequired());
+                keyManagerConfigurationDTO.setMask(configurationDto.isMask());
+                keyManagerConfigurationDTO.setMultiple(configurationDto.isMultiple());
+                keyManagerConfigurationDTO.setTooltip(configurationDto.getTooltip());
+                keyManagerConfigurationDTO.setDefault(configurationDto.getDefaultValue());
+                keyManagerConfigurationDTO.setValues(configurationDto.getValues());
                 settingsKeyManagerConfigurationDTO.getEndpointConfigurations().add(keyManagerConfigurationDTO);
             }
         }
         return settingsKeyManagerConfigurationDTO;
     }
 
-    private static List<SettingsFederatedGatewayConfigurationDTO> getSettingsFederatedGatewayConfigurationDTOList() {
-        List<SettingsFederatedGatewayConfigurationDTO> list = new ArrayList<>();
+    private static List<SettingsGatewayConfigurationDTO> getSettingsGatewayConfigurationDTOList() {
+        List<SettingsGatewayConfigurationDTO> list = new ArrayList<>();
         Map<String, ExternalGatewayDeployer> externalGatewayConnectorConfigurationMap =
                 ServiceReferenceHolder.getInstance().getExternalGatewayDeployers();
         externalGatewayConnectorConfigurationMap.forEach((gatewayName, gatewayConfiguration) -> {
-            SettingsFederatedGatewayConfigurationDTO settingsFederatedGatewayConfigurationDTO =
-                    new SettingsFederatedGatewayConfigurationDTO();
+            SettingsGatewayConfigurationDTO settingsFederatedGatewayConfigurationDTO =
+                    new SettingsGatewayConfigurationDTO();
             settingsFederatedGatewayConfigurationDTO.setType(gatewayConfiguration.getType());
             settingsFederatedGatewayConfigurationDTO.setDisplayName(gatewayConfiguration.getType());
             List<ConfigurationDto> connectionConfigurations = gatewayConfiguration.getConnectionConfigurations();
@@ -150,7 +165,7 @@ public class SettingsMappingUtil {
         //Add APK and Synapse Gateways configured through toml to the list
         List<String> gatewayTypesFromConfig = APIUtil.getGatewayTypes();
         for (String type : gatewayTypesFromConfig) {
-            SettingsFederatedGatewayConfigurationDTO gateway = new SettingsFederatedGatewayConfigurationDTO();
+            SettingsGatewayConfigurationDTO gateway = new SettingsGatewayConfigurationDTO();
             gateway.setType(type);
             gateway.setDisplayName(type);
             if (list.stream().noneMatch(obj -> obj.getType().equals(type))) {
@@ -160,8 +175,8 @@ public class SettingsMappingUtil {
         return list;
     }
 
-    private static ConfigurationDTO fromConfigurationToConfigurationDTO(ConfigurationDto configuration) {
-        ConfigurationDTO dto = new ConfigurationDTO();
+    private static GatewayConfigurationDTO fromConfigurationToConfigurationDTO(ConfigurationDto configuration) {
+        GatewayConfigurationDTO dto = new GatewayConfigurationDTO();
         dto.setName(configuration.getName());
         dto.setLabel(configuration.getLabel());
         dto.setType(configuration.getType());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -1943,6 +1943,41 @@ paths:
   # The "Individual Environment" resource APIs
   ######################################################
   /environments/{environmentId}:
+    get:
+      tags:
+        - Environments
+      summary: Get a Gateway Environment Configuration
+      description: |
+        Retrieve a single Gateway Environment Configuration. We should provide the Id of the Environment as a path parameter.
+      parameters:
+        - $ref: '#/components/parameters/environmentId'
+      responses:
+        200:
+          description: |
+            OK.
+            Gateway Environment Configuration returned
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Environment'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:environment_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/admin/v4/environments/8d263942-a6df-4cc2-a804-7a2525501450"'
     put:
       tags:
         - Environments
@@ -5201,9 +5236,6 @@ components:
         host:
           maxLength: 255
           minLength: 1
-          # hostname regex as per RFC 1123 (http://tools.ietf.org/html/rfc1123) and appended *
-          # included {} to allow hostname templates
-          pattern: '^(([a-zA-Z0-9\{\}]|[a-zA-Z0-9\{\}][a-zA-Z0-9\-\{\}]*[a-zA-Z0-9\{\}])\.)*([A-Za-z0-9\{\}]|[A-Za-z0-9\{\}][A-Za-z0-9\-\{\}]*[A-Za-z0-9\{\}])$'
           type: string
           example: mg.wso2.com
         httpContext:
@@ -5433,12 +5465,12 @@ components:
               configurations:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Configuration'
+                  $ref: '#/components/schemas/KeyManagerConfiguration'
               endpointConfigurations:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Configuration'
-        federatedGatewayConfiguration:
+                  $ref: '#/components/schemas/KeyManagerConfiguration'
+        gatewayConfiguration:
           type: array
           items:
             type: object
@@ -5452,7 +5484,7 @@ components:
               configurations:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Configuration'
+                  $ref: '#/components/schemas/GatewayConfiguration'
         analyticsEnabled:
           type: boolean
           description: To determine whether analytics is enabled or not
@@ -5744,8 +5776,42 @@ components:
             - EXCHANGED
             - DIRECT
             - BOTH
-    Configuration:
-      title: Custom Configuration
+    KeyManagerConfiguration:
+      title: Key Manager Configuration
+      type: object
+      properties:
+        name:
+          type: string
+          example: consumer_key
+        label:
+          type: string
+          example: Consumer Key
+        type:
+          type: string
+          example: select
+        required:
+          type: boolean
+          example: true
+        mask:
+          type: boolean
+          example: true
+        multiple:
+          type: boolean
+          example: true
+        tooltip:
+          type: string
+          example: Enter username to connect to key manager
+        default:
+          type: object
+          properties: { }
+          example: admin
+        values:
+          type: array
+          items:
+            type: object
+            properties: { }
+    GatewayConfiguration:
+      title: Gateway Configuration
       type: object
       properties:
         name:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
@@ -1943,6 +1943,41 @@ paths:
   # The "Individual Environment" resource APIs
   ######################################################
   /environments/{environmentId}:
+    get:
+      tags:
+        - Environments
+      summary: Get a Gateway Environment Configuration
+      description: |
+        Retrieve a single Gateway Environment Configuration. We should provide the Id of the Environment as a path parameter.
+      parameters:
+        - $ref: '#/components/parameters/environmentId'
+      responses:
+        200:
+          description: |
+            OK.
+            Gateway Environment Configuration returned
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Environment'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:environment_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/admin/v4/environments/8d263942-a6df-4cc2-a804-7a2525501450"'
     put:
       tags:
         - Environments
@@ -5201,9 +5236,6 @@ components:
         host:
           maxLength: 255
           minLength: 1
-          # hostname regex as per RFC 1123 (http://tools.ietf.org/html/rfc1123) and appended *
-          # included {} to allow hostname templates
-          pattern: '^(([a-zA-Z0-9\{\}]|[a-zA-Z0-9\{\}][a-zA-Z0-9\-\{\}]*[a-zA-Z0-9\{\}])\.)*([A-Za-z0-9\{\}]|[A-Za-z0-9\{\}][A-Za-z0-9\-\{\}]*[A-Za-z0-9\{\}])$'
           type: string
           example: mg.wso2.com
         httpContext:
@@ -5433,12 +5465,12 @@ components:
               configurations:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Configuration'
+                  $ref: '#/components/schemas/KeyManagerConfiguration'
               endpointConfigurations:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Configuration'
-        federatedGatewayConfiguration:
+                  $ref: '#/components/schemas/KeyManagerConfiguration'
+        gatewayConfiguration:
           type: array
           items:
             type: object
@@ -5452,7 +5484,7 @@ components:
               configurations:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Configuration'
+                  $ref: '#/components/schemas/GatewayConfiguration'
         analyticsEnabled:
           type: boolean
           description: To determine whether analytics is enabled or not
@@ -5744,8 +5776,42 @@ components:
             - EXCHANGED
             - DIRECT
             - BOTH
-    Configuration:
-      title: Custom Configuration
+    KeyManagerConfiguration:
+      title: Key Manager Configuration
+      type: object
+      properties:
+        name:
+          type: string
+          example: consumer_key
+        label:
+          type: string
+          example: Consumer Key
+        type:
+          type: string
+          example: select
+        required:
+          type: boolean
+          example: true
+        mask:
+          type: boolean
+          example: true
+        multiple:
+          type: boolean
+          example: true
+        tooltip:
+          type: string
+          example: Enter username to connect to key manager
+        default:
+          type: object
+          properties: { }
+          example: admin
+        values:
+          type: array
+          items:
+            type: object
+            properties: { }
+    GatewayConfiguration:
+      title: Gateway Configuration
       type: object
       properties:
         name:


### PR DESCRIPTION
This PR will,
  - remove hostname validation regex
  - rename federatedGatewayConfiguration DTO field to gatewayConfiguration
  - bring back KeyManagerConfiguration schema and define a new schema for GatewayConfiguration
  - Adds a /GET for /environment/{environmentID}
  - Encrypts sercret fields in environment configurations